### PR TITLE
added hasPending and PendingBytes as methods in TCPSSLClient and TCPS…

### DIFF
--- a/Socket/TCPSSLClient.cpp
+++ b/Socket/TCPSSLClient.cpp
@@ -174,6 +174,20 @@ bool CTCPSSLClient::Send(const std::vector<char>& Data) const
    return Send(Data.data(), Data.size());
 }
 
+bool CTCPSSLClient::HasPending()
+{
+   int pend = SSL_has_pending(m_SSLConnectSocket.m_pSSL);
+
+   return pend == 1;
+}
+
+int CTCPSSLClient::PendingBytes()
+{
+   int nPend = SSL_pending(m_SSLConnectSocket.m_pSSL);
+
+   return nPend;
+}
+
 int CTCPSSLClient::Receive(char* pData, const size_t uSize, bool bReadFully /*= true*/) const
 {
    if (m_TCPClient.m_eStatus != CTCPClient::CONNECTED)

--- a/Socket/TCPSSLClient.h
+++ b/Socket/TCPSSLClient.h
@@ -36,7 +36,10 @@ public:
    bool Send(const std::vector<char>& Data) const;
 
    /* receive data from a TCP SSL server */
-   int  Receive(char* pData, const size_t uSize, bool bReadFully = true) const;
+   bool HasPending();
+   int PendingBytes();
+
+   int Receive(char* pData, const size_t uSize, bool bReadFully = true) const;
 
 protected:
    CTCPClient  m_TCPClient;

--- a/Socket/TCPSSLServer.cpp
+++ b/Socket/TCPSSLServer.cpp
@@ -121,6 +121,20 @@ bool CTCPSSLServer::Listen(SSLSocket& ClientSocket, size_t msec /*= ACCEPT_WAIT_
    return false;
 }
 
+bool CTCPSSLServer::HasPending(const SSLSocket& ClientSocket)
+{
+   int pend = SSL_has_pending(ClientSocket.m_pSSL);
+
+   return pend == 1;
+}
+
+int CTCPSSLServer::PendingBytes(const SSLSocket& ClientSocket)
+{
+   int nPend = SSL_pending(ClientSocket.m_pSSL);
+
+   return nPend;
+}
+
 /* When an SSL_read() operation has to be repeated because of SSL_ERROR_WANT_READ or SSL_ERROR_WANT_WRITE,
  * it must be repeated with the same arguments.*/
 int CTCPSSLServer::Receive(const SSLSocket& ClientSocket, 

--- a/Socket/TCPSSLServer.h
+++ b/Socket/TCPSSLServer.h
@@ -32,6 +32,8 @@ public:
 
    bool Listen(SSLSocket& ClientSocket, size_t msec = ACCEPT_WAIT_INF_DELAY);
 
+   bool HasPending(const SSLSocket& ClientSocket);
+   int PendingBytes(const SSLSocket& ClientSocket);
    int Receive(const SSLSocket& ClientSocket, char* pData,
                const size_t uSize, bool bReadFully = true) const;
 


### PR DESCRIPTION
…SLServer to lookup if a connection has bytes to fetch

Integration of OpenSSL methods pending and has_pending

Does not test if errors occured, as both methods do not return error codes (according to the OpenSSL documentation).